### PR TITLE
fix createOffer constraints

### DIFF
--- a/snoop.js
+++ b/snoop.js
@@ -73,7 +73,12 @@
         var nativeMethod = pc[method];
         pc[method] = function() {
           var args = arguments;
-          var opts = arguments.length === 1 && typeof arguments[0] === 'object' ? arguments[0] : undefined;
+          var opts = undefined;
+          if (arguments.length === 1 && typeof arguments[0] === 'object') {
+            opts = arguments[0];
+          } else if (arguments.length === 3 && typeof arguments[2] === 'object') {
+            opts = arguments[2];
+          }
           trace(method, id, opts);
           return new Promise(function(resolve, reject) {
             nativeMethod.apply(pc, [


### PR DESCRIPTION
or how I filed a chrome bug because of a bug in my evil JS for the second time.
This works for both
createOffer(opts)
as well as
createOffer(success, err, opts)
Who is using non-promise versions anyway... :-)
