### PR TITLE
improved GUM stream dump format

### DIFF
--- a/snoop.js
+++ b/snoop.js
@@ -202,6 +202,7 @@
         return {
           id: track.id,
           kind: track.kind,
+          label: track.label, // contains information about the hardware
           readyState: track.readyState
         };
       })

--- a/snoop.js
+++ b/snoop.js
@@ -195,6 +195,18 @@
   }
 
   // getUserMedia wrappers
+  function dumpStream(stream) {
+    return {
+      id: stream.id,
+      tracks: stream.getTracks().map(function(track) {
+        return {
+          id: track.id,
+          kind: track.kind,
+          readyState: track.readyState
+        };
+      })
+    };
+  }
   if (navigator.webkitGetUserMedia || navigator.mozGetUserMedia) {
     var origGetUserMedia = navigator.webkitGetUserMedia ?
         navigator.webkitGetUserMedia.bind(navigator) :
@@ -205,8 +217,9 @@
       var eb = arguments[2];
       origGetUserMedia(arguments[0],
         function(stream) {
-          trace('getUserMediaOnSuccess', null,
-              stream.id + ' ' + stream.getTracks().map(function(t) { return t.kind + ':' + t.id; }));
+          // we log the stream id, track ids and tracks readystate since that is ended GUM fails
+          // to acquire the cam (in chrome)
+          trace('getUserMediaOnSuccess', null, dumpStream(stream));
           if (cb) {
             cb(stream);
           }
@@ -231,8 +244,7 @@
       trace('navigator.mediaDevices.getUserMedia', null, arguments[0]);
       var p = gum2.apply(navigator.mediaDevices, arguments);
       p.then(function(stream) {
-        trace('navigator.mediaDevices.getUserMediaOnSuccess', null,
-            stream.id + ' ' + stream.getTracks().map(function(t) { return t.kind + ':' + t.id; }));
+        trace('navigator.mediaDevices.getUserMediaOnSuccess', null, dumpStream(stream));
       });
       p.then(null, function(err) {
         trace('navigator.mediaDevices.getUserMediaOnFailure', null, err);


### PR DESCRIPTION
in particular, this allows detecting the case where (in Chrome) getUserMedia works but fails to acquire the camera (possibly also the microphone) because it is used by another process. In that case, the track's readyState is ended.
