### PR TITLE
Send WS protocol Version

### DIFF
--- a/rtcstats.js
+++ b/rtcstats.js
@@ -1,8 +1,9 @@
 'use strict';
 (function() {
   var wsURL = 'wss://rtcstats.tokbox.com/';
+  var PROTOCOL_VERSION = '1.0';
   var buffer = [];
-  var connection = new WebSocket(wsURL + window.location.pathname);
+  var connection = new WebSocket(wsURL + window.location.pathname, PROTOCOL_VERSION);
   connection.onerror = function(e) {
     console.log('WS ERROR', e);
   };

--- a/websocket.js
+++ b/websocket.js
@@ -16,8 +16,17 @@ pem.createCertificate({ days: 1, selfSigned: true }, function (err, keys) {
         key: keys.serviceKey,
         cert: keys.certificate
     });
+    var PROTOCOL_VERSION = '1.0';
+
     server.listen(3000);
-    wss = new WebSocketServer({ server: server });
+    var handleProtocols = function (protocols, cb) {
+        // https://github.com/websockets/ws/blob/master/doc/ws.md#optionshandleprotocols
+        // Accept any protocol version and notify the client we will use
+        // PROTOCOL_VERSION
+        cb(true, PROTOCOL_VERSION);
+    };
+
+    wss = new WebSocketServer({ server: server, handleProtocols: handleProtocols });
 
     wss.on('connection', function(client) {
         var referer = client.upgradeReq.headers['origin'] + client.upgradeReq.url;


### PR DESCRIPTION
The `Sec-WebSocket-Protocol` header field is used in the WebSocket 
opening handshake.  It is sent from the client to the server and back
from the server to the client to confirm the subprotocol of the
connection.  This enables scripts to both select a subprotocol and be
sure that the server agreed to serve that subprotocol.

https://tools.ietf.org/html/rfc6455#section-11.3.4

The idea is to prevent requiring backwards compatibility if it happens
that we want to change the payload we’re sending to the server
