### PR TITLE
‘use strict’ should be included in IIFE

### DIFF
--- a/rtcstats.js
+++ b/rtcstats.js
@@ -1,5 +1,6 @@
-'use strict';
 (function() {
+  'use strict';
+
   var wsURL = 'wss://rtcstats.tokbox.com/';
   var buffer = [];
   var connection = new WebSocket(wsURL + window.location.pathname);


### PR DESCRIPTION
It’s a bad practice to execute ‘use strict’ in the
global scope, as it could have an unexpected behaviour in other scripts loaded in the web page (mainly if the use concatenates several JS files in one).
