### PR TITLE
drop getstats when not connected

### DIFF
--- a/trace-ws.js
+++ b/trace-ws.js
@@ -31,7 +31,7 @@ module.exports = function(wsURL) {
     args.push(new Date().getTime());
     if (connection.readyState === 1) {
       connection.send(JSON.stringify(args));
-    } else {
+    } else if (args[0] !== 'getstats') {
       buffer.push(args);
     }
   }


### PR DESCRIPTION
since the amount of data that could accumulate could be pretty high. I'd rather drop it than bog down my site.
