### PR TITLE
REMOVE opentok eslint dependency and add fixes for latest versions of eslint and airbnb style

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,5 @@
-{
-  "extends": "eslint-config-opentok",
+ {
+  "extends": "eslint-config-airbnb",
   "rules": {
     "no-eq-null": 0,
     "vars-on-top": 0,
@@ -7,8 +7,17 @@
     "no-alert": 0,
     "spaced-comment": 0,
     "valid-jsdoc": 0,
+    "prefer-arrow-callback": 0,
+    "prefer-rest-params": 0,
+    "space-before-function-paren": 0,
+    "no-var": 0,
+    "strict": 0,
+    "func-names": 0,
+    "no-plusplus": 0,
+    "prefer-template": 0,
+    "object-shorthand": 0,
 
-    "no-use-before-define": 0,
+    "no-undef": 0,
     "new-cap": 0,
     "no-param-reassign": 0,
     "consistent-this": 0,

--- a/package.json
+++ b/package.json
@@ -9,9 +9,13 @@
   },
   "devDependencies": {
     "chromedriver": "^2.16.0",
-    "eslint": "^1.10.3",
-    "eslint-config-opentok": "1.0.2",
-    "eslint-plugin-require-path-exists": "^1.0.15",
+    "eslint": "^3.12.2",
+    "eslint-config-airbnb": "^13.0.0",
+    "eslint-config-airbnb-base": "^11.0.0",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^2.2.3",
+    "eslint-plugin-react": "^6.8.0",
+    "eslint-plugin-require-path-exists": "^1.1.5",
     "selenium-webdriver": "^2.48.0",
     "tape": "^4.0.0",
     "testling": "^1.7.1",
@@ -20,7 +24,7 @@
     "webrtc-adapter-test": "^0.2.7"
   },
   "scripts": {
-    "test": "eslint rtcstats.js",
+    "test": "./node_modules/.bin/eslint rtcstats.js",
     "dist": "uglifyjs -o min.js rtcstats.js",
     "test-travis": "cp test/testpage.html node_modules/webrtc-adapter-test/ && test/run-tests"
   },


### PR DESCRIPTION
1) Removed the dependency with the deprecated opentok-eslint-config that doesn't work with latest eslint versions.  We use airbnb-eslint-config out of the box now.
2) Added eslint as dev dependency.
3) Minor changes in the code to comply with the latest version of airbnb-eslint-config (commas at the end of dictionaries, change order of definitions...)
4) Ignored many warnings because I'm not sure we want to make rtcstats require es6 (IE?).   We can review this later.

wdyt @fippo ?