### PR TITLE
override the correct RTCPeerConnection

### DIFF
--- a/rtcstats.js
+++ b/rtcstats.js
@@ -107,11 +107,11 @@
     }
   }
 
-  var origPeerConnection = window.webkitRTCPeerConnection ||
-    window.RTCPeerConnection || window.mozRTCPeerConnection;
+  var origPeerConnection = window.RTCPeerConnection ||
+    window.webkitRTCPeerConnection || window.mozRTCPeerConnection;
   if (origPeerConnection) {
     var peerconnectioncounter = 0;
-    var isChrome = origPeerConnection === window.webkitRTCPeerConnection;
+    var isChrome = !!window.webkitRTCPeerConnection;
     var peerconnection = function(config, constraints) {
       var id = 'PC_' + peerconnectioncounter++;
       var pc = new origPeerConnection(config, constraints);
@@ -284,13 +284,14 @@
         },
       });
     }
-    if (window.webkitRTCPeerConnection) {
-      window.webkitRTCPeerConnection = peerconnection;
-      window.webkitRTCPeerConnection.prototype = origPeerConnection.prototype;
-    } else if (window.RTCPeerConnection) {
+
+    if (origPeerConnection === window.RTCPeerConnection) {
       window.RTCPeerConnection = peerconnection;
       window.RTCPeerConnection.prototype = origPeerConnection.prototype;
-    } else {
+    } else if (origPeerConnection === window.webkitRTCPeerConnection) {
+      window.webkitRTCPeerConnection = peerconnection;
+      window.webkitRTCPeerConnection.prototype = origPeerConnection.prototype;
+    } else if (origPeerConnection === window.mozRTCPeerConnection) {
       window.mozRTCPeerConnection = peerconnection;
       window.mozRTCPeerConnection.prototype = origPeerConnection.prototype;
     }

--- a/rtcstats.js
+++ b/rtcstats.js
@@ -107,11 +107,13 @@
     }
   }
 
-  var origPeerConnection = window.RTCPeerConnection ||
-    window.webkitRTCPeerConnection || window.mozRTCPeerConnection;
-  if (origPeerConnection) {
-    var peerconnectioncounter = 0;
-    var isChrome = !!window.webkitRTCPeerConnection;
+  var peerconnectioncounter = 0;
+  var isChrome = !!window.webkitRTCPeerConnection;
+  ['', 'webkit', 'moz'].forEach(function(prefix) {
+    if (!window[prefix + 'RTCPeerConnection']) {
+      return;
+    }
+    var origPeerConnection = window[prefix + 'RTCPeerConnection'];
     var peerconnection = function(config, constraints) {
       var id = 'PC_' + peerconnectioncounter++;
       var pc = new origPeerConnection(config, constraints);
@@ -284,18 +286,9 @@
         },
       });
     }
-
-    if (origPeerConnection === window.RTCPeerConnection) {
-      window.RTCPeerConnection = peerconnection;
-      window.RTCPeerConnection.prototype = origPeerConnection.prototype;
-    } else if (origPeerConnection === window.webkitRTCPeerConnection) {
-      window.webkitRTCPeerConnection = peerconnection;
-      window.webkitRTCPeerConnection.prototype = origPeerConnection.prototype;
-    } else if (origPeerConnection === window.mozRTCPeerConnection) {
-      window.mozRTCPeerConnection = peerconnection;
-      window.mozRTCPeerConnection.prototype = origPeerConnection.prototype;
-    }
-  }
+    window[prefix + 'RTCPeerConnection'] = peerconnection;
+    window[prefix + 'RTCPeerConnection'].prototype = origPeerConnection.prototype;
+  });
 
   // getUserMedia wrappers
   function dumpStream(stream) {


### PR DESCRIPTION
I just notice this broke in Chrome 56 because it continued to override
webkitRTCPeerConnection. adapter.js stopped using webkitRTCPeerConnection
in 3.x which meant the RTCPeerConnection used by downstream was not overridden.

This should probably override both RTCPeerConnection and
(webkit|moz)RTCPeerConnection but for now this solves my problem.