### PR TITLE
Disallow trailing commas in function calls

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -22,7 +22,15 @@
     "no-param-reassign": 0,
     "consistent-this": 0,
 
-    "no-warning-comments": 0
+    "no-warning-comments": 0,
+     
+    "comma-dangle": ["error", {
+        "arrays": "only-multiline",
+        "objects": "only-multiline",
+        "imports": "only-multiline",
+        "exports": "only-multiline",
+        "functions": "never",
+    }],
   },
   "plugins": [
     "require-path-exists"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "webrtc-adapter-test": "^0.2.7"
   },
   "scripts": {
-    "test": "./node_modules/.bin/eslint rtcstats.js",
+    "test": "./node_modules/.bin/eslint rtcstats.js && npm run dist",
     "dist": "uglifyjs -o min.js rtcstats.js",
     "test-travis": "cp test/testpage.html node_modules/webrtc-adapter-test/ && test/run-tests"
   },

--- a/rtcstats.js
+++ b/rtcstats.js
@@ -217,7 +217,7 @@
                 if (args.length >= 3) {
                   args[2].apply(null, [err]);
                 }
-              }],
+              }]
             );
           });
         };
@@ -331,7 +331,7 @@
           if (eb) {
             eb(err);
           }
-        },
+        }
       );
     };
     if (navigator.webkitGetUserMedia) {


### PR DESCRIPTION
This PR does:

* Removes trailing commas from function calls (they prevented uglify from processing the file)
* Changes the eslint config so that it will catch them
* Run uglify after running eslint during tests so that if uglify fails it fails the build