### PR TITLE
add module version of rtcstats

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,15 @@ var pc = new RTCPeerConnection(yourConfiguration, {
 })
 ```
 
-Integrating as a module is currently not supported.
+### requiring as module
+```
+require('./rtcstats')(
+    'wss://rtcstats.tokbox.com', // url-to-your-websocker-server
+    1000, // interval at which getStats will be polled,
+    ['', 'webkit', 'moz'] // RTCPeerConnection prefixes to wrap.
+);
+```
+When using ontop of adapter it is typically not necessary (and potentially harmful to shim the webkit and moz prefixes in addition to the unprefixed version.
 
 ## Importing the dumps
 The dumps generated can be imported and visualized using [this tool](https://fippo.github.io/webrtc-dump-importer/rtcstats)

--- a/nonmodule.js
+++ b/nonmodule.js
@@ -1,0 +1,6 @@
+// helper script to create the non-module version with some defaults.
+require('./rtcstats')(
+    'wss://rtcstats.tokbox.com',
+    1000,
+    ['', 'webkit', 'moz']
+);

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "eslint-plugin-react": "^6.8.0",
     "eslint-plugin-require-path-exists": "^1.1.5",
     "geckodriver": "1.4.0",
-    "selenium-webdriver": "^3.3.0",
+    "selenium-webdriver": "3.3.0",
     "tape": "^4.0.0",
     "testling": "^1.7.1",
     "travis-multirunner": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "ws": "^0.8.1"
   },
   "devDependencies": {
+    "browserify": "^14.3.0",
     "chromedriver": "2.28.0",
     "eslint": "^3.12.2",
     "eslint-config-airbnb": "^13.0.0",
@@ -25,9 +26,11 @@
     "webrtc-adapter": "^3.2.0"
   },
   "scripts": {
-    "test": "./node_modules/.bin/eslint rtcstats.js && npm run dist",
-    "dist": "uglifyjs -o min.js rtcstats.js",
-    "test-travis": "cp test/testpage.html node_modules/webrtc-adapter/test/ && test/run-tests"
+    "test": "./node_modules/.bin/eslint rtcstats.js nonmodule.js && npm run dist",
+    "dist": "mkdir -p out && browserify -o out/rtcstats.js nonmodule.js && uglifyjs -o min.js out/rtcstats.js",
+    "pre-adapter": "cp test/pre-adapter.html test/testpage.html && test/run-tests",
+    "post-adapter": "cp test/post-adapter.html test/testpage.html && test/run-tests",
+    "test-travis": "npm run pre-adapter && npm run post-adapter"
   },
   "repository": {
     "type": "git",

--- a/rtcstats.js
+++ b/rtcstats.js
@@ -152,6 +152,10 @@ module.exports = function(wsURL, getStatsInterval, prefixesToWrap) {
     if (!window[prefix + 'RTCPeerConnection']) {
       return;
     }
+    if (prefix === 'webkit' && window.RTCIceGatherer) {
+      // dont wrap webkitRTCPeerconnection in Edge.
+      return;
+    }
     var origPeerConnection = window[prefix + 'RTCPeerConnection'];
     var peerconnection = function(config, constraints) {
       var id = 'PC_' + peerconnectioncounter++;

--- a/test/post-adapter.html
+++ b/test/post-adapter.html
@@ -6,15 +6,15 @@
 <body>
 <h1>Test page for adapter.js</h1>
 <script src="../node_modules/webrtc-adapter/out/adapter.js"></script>
-<script src="../rtcstats.js"></script>
+<script src="../out/rtcstats.js"></script>
 The browser is: <span id="browser"></span>
 <br>
 The browser version is: <span id="browserversion"></span>
 <script>
   var browser_display = document.getElementById('browser');
   var version_display = document.getElementById('browserversion');
-  browser_display.innerHTML = webrtcDetectedBrowser;
-  version_display.innerHTML = webrtcDetectedVersion;
+  browser_display.innerHTML = adapter.browserDetails.browser;
+  version_display.innerHTML = adapter.browserDetails.version;
 </script>
 </body>
 </html>

--- a/test/pre-adapter.html
+++ b/test/pre-adapter.html
@@ -1,0 +1,20 @@
+<html>
+<head>
+<meta charset="utf-8">
+<title>Test page for adapter.js</title>
+</head>
+<body>
+<h1>Test page for adapter.js</h1>
+<script src="../out/rtcstats.js"></script>
+<script src="../node_modules/webrtc-adapter/out/adapter.js"></script>
+The browser is: <span id="browser"></span>
+<br>
+The browser version is: <span id="browserversion"></span>
+<script>
+  var browser_display = document.getElementById('browser');
+  var version_display = document.getElementById('browserversion');
+  browser_display.innerHTML = adapter.browserDetails.browser;
+  version_display.innerHTML = adapter.browserDetails.version;
+</script>
+</body>
+</html>


### PR DESCRIPTION
adds a version of rtcstats which is exported as a module.
Most importantly this allows me to insert it after adapter.js
so that my Edge shim can be monitored.

Still haven't figured out a good way how to maintain both versions.