### PR TITLE
rtcstats: call err.toString()

### DIFF
--- a/rtcstats.js
+++ b/rtcstats.js
@@ -229,7 +229,7 @@ module.exports = function(wsURL, getStatsInterval, prefixesToWrap) {
                   }
                 },
                 function(err) {
-                  trace(method + 'OnFailure', id, err);
+                  trace(method + 'OnFailure', id, err.toString());
                   reject(err);
                   if (args.length > 1 && typeof args[1] === 'function') {
                     args[1].apply(null, [err]);
@@ -258,7 +258,7 @@ module.exports = function(wsURL, getStatsInterval, prefixesToWrap) {
                   }
                 },
                 function(err) {
-                  trace(method + 'OnFailure', id, err);
+                  trace(method + 'OnFailure', id, err.toString());
                   reject(err);
                   if (args.length >= 3) {
                     args[2].apply(null, [err]);


### PR DESCRIPTION
it seems that the errors are now DOMExceptions which get serialized to {} by JSON.stringify
which in turn gets interpreted as empty string by redshift. So SLD/SRD errors were hidden
for modern browsers.