### PR TITLE
safari: dont call chrome legacy stats

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "devDependencies": {
     "browserify": "^14.3.0",
-    "chromedriver": "2.28.0",
+    "chromedriver": "^2.29.0",
     "eslint": "^3.12.2",
     "eslint-config-airbnb": "^13.0.0",
     "eslint-config-airbnb-base": "^11.0.0",
@@ -21,7 +21,7 @@
     "testling": "^1.7.1",
     "travis-multirunner": "^3.0.0",
     "uglify-js": "^2.6.1",
-    "webrtc-adapter": "^3.2.0"
+    "webrtc-adapter": "^4.0.0"
   },
   "scripts": {
     "test": "./node_modules/.bin/eslint rtcstats.js nonmodule.js && npm run dist",

--- a/rtcstats.js
+++ b/rtcstats.js
@@ -149,6 +149,7 @@ module.exports = function(wsURL, getStatsInterval, prefixesToWrap) {
   var peerconnectioncounter = 0;
   var isFirefox = !!window.mozRTCPeerConnection;
   var isEdge = !!window.RTCIceGatherer;
+  var isSafari = !isFirefox && window.RTCPeerConnection && !window.webkitRTCPeerConnection;
   prefixesToWrap.forEach(function(prefix) {
     if (!window[prefix + 'RTCPeerConnection']) {
       return;
@@ -309,7 +310,7 @@ module.exports = function(wsURL, getStatsInterval, prefixesToWrap) {
             window.clearInterval(interval);
             return;
           }
-          if (isFirefox) {
+          if (isFirefox || isSafari) {
             pc.getStats(null, function(res) {
               var now = map2obj(res);
               var base = JSON.parse(JSON.stringify(now)); // our new prev


### PR DESCRIPTION
do not attempt to call chrome style legacy stats in Safari