### PR TITLE
remove window.rtcstats global

### DIFF
--- a/rtcstats.js
+++ b/rtcstats.js
@@ -382,8 +382,4 @@ module.exports = function(trace, getStatsInterval, prefixesToWrap) {
     }
   });
   */
-
-  window.rtcstats = {
-    trace: trace,
-  };
 };


### PR DESCRIPTION
this was used as a way to export trace, however trace can be passed in now.

breaking change