### PR TITLE
ci: upgrade adapter to custom 4.x version with travis fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,7 @@
   "version": "2.1.0",
   "description": "gather WebRTC API traces and statistics",
   "main": "rtcstats.js",
-  "dependencies": {
-  },
+  "dependencies": {},
   "devDependencies": {
     "browserify": "^14.3.0",
     "chromedriver": "^2.29.0",
@@ -21,7 +20,7 @@
     "testling": "^1.7.1",
     "travis-multirunner": "^3.0.0",
     "uglify-js": "^2.6.1",
-    "webrtc-adapter": "^4.0.0"
+    "webrtc-adapter": "https://github.com/fippo/adapter#v4.2.2-no-sandbox"
   },
   "scripts": {
     "test": "./node_modules/.bin/eslint rtcstats.js nonmodule.js && npm run dist",

--- a/test/post-adapter.html
+++ b/test/post-adapter.html
@@ -5,7 +5,7 @@
 </head>
 <body>
 <h1>Test page for adapter.js</h1>
-<script src="../node_modules/webrtc-adapter/out/adapter.js"></script>
+<script src="https://webrtc.github.io/adapter/adapter-4.2.2.js"></script>
 <script src="../out/rtcstats.js"></script>
 The browser is: <span id="browser"></span>
 <br>

--- a/test/pre-adapter.html
+++ b/test/pre-adapter.html
@@ -6,7 +6,7 @@
 <body>
 <h1>Test page for adapter.js</h1>
 <script src="../out/rtcstats.js"></script>
-<script src="../node_modules/webrtc-adapter/out/adapter.js"></script>
+<script src="https://webrtc.github.io/adapter/adapter-4.2.2.js"></script>
 The browser is: <span id="browser"></span>
 <br>
 The browser version is: <span id="browserversion"></span>


### PR DESCRIPTION
uses a version with no-sandbox for chrome which is now required
on travis