### PR TITLE
use prototypes instead of overloading instance methods

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,7 @@
  {
   "extends": "eslint-config-airbnb",
   "rules": {
+    "no-underscore-dangle": 0,
     "no-eq-null": 0,
     "vars-on-top": 0,
     "no-console": 0,


### PR DESCRIPTION
mostly to avoid using a different style than adapter.
Memory savings are probably marginal

(probably a major version bump to to be on the safe side)