### PR TITLE
do not attempt to compress timestamps

### DIFF
--- a/rtcstats.js
+++ b/rtcstats.js
@@ -26,14 +26,13 @@ function deltaCompression(oldStats, newStats) {
       if (report[name] === oldStats[id][name]) {
         delete newStats[id][name];
       }
-      delete report.timestamp;
       if (Object.keys(report).length === 0) {
+        delete newStats[id];
+      } else if (Object.keys(report).length === 1 && report.timestamp) {
         delete newStats[id];
       }
     });
   });
-  // TODO: moving the timestamp to the top-level is not compression but...
-  newStats.timestamp = new Date();
   return newStats;
 }
 

--- a/trace-ws.js
+++ b/trace-ws.js
@@ -1,4 +1,4 @@
-var PROTOCOL_VERSION = '1.0';
+var PROTOCOL_VERSION = '2.0';
 module.exports = function(wsURL) {
   var buffer = [];
   var connection = new WebSocket(wsURL + window.location.pathname, PROTOCOL_VERSION);


### PR DESCRIPTION
for multistream where streams are removed and stats can disappear this does not work
Bumps the WS protocol version to 2.0 as this is a wire-protocol change