### PR TITLE
add close and connect functions to the tracer

### DIFF
--- a/trace-ws.js
+++ b/trace-ws.js
@@ -1,39 +1,52 @@
 var PROTOCOL_VERSION = '1.0';
 module.exports = function(wsURL) {
-  var buffer = [];
-  var connection = new WebSocket(wsURL + window.location.pathname, PROTOCOL_VERSION);
-  connection.onerror = function(e) {
-    console.log('WS ERROR', e);
-  };
-
-  /*
-  connection.onclose = function() {
-    // reconnect?
-  };
-  */
-
-  connection.onopen = function() {
-    while (buffer.length) {
-      connection.send(JSON.stringify(buffer.shift()));
-    }
-  };
-
-  /*
-  connection.onmessage = function(msg) {
-    // no messages from the server defined yet.
-  };
-  */
-
-  function trace() {
+  var buffer;
+  var connection;
+  var trace = function() {
     //console.log.apply(console, arguments);
     // TODO: drop getStats when not connected?
     var args = Array.prototype.slice.call(arguments);
     args.push(new Date().getTime());
-    if (connection.readyState === 1) {
+    if (connection.readyState === WebSocket.OPEN) {
       connection.send(JSON.stringify(args));
+    } else if (connection.readyState >= WebSocket.CLOSING) {
+      // no-op. Possibly log?
     } else if (args[0] !== 'getstats') {
       buffer.push(args);
     }
-  }
+  };
+
+  trace.close = function() {
+    connection.close();
+  };
+  trace.connect = function() {
+    buffer = [];
+    if (connection) {
+      connection.close();
+    }
+    connection = new WebSocket(wsURL + window.location.pathname, PROTOCOL_VERSION);
+    connection.onerror = function(e) {
+      console.log('WS ERROR', e);
+    };
+
+    /*
+    connection.onclose = function() {
+      // reconnect?
+    };
+    */
+
+    connection.onopen = function() {
+      while (buffer.length) {
+        connection.send(JSON.stringify(buffer.shift()));
+      }
+    };
+
+    /*
+    connection.onmessage = function(msg) {
+      // no messages from the server defined yet.
+    };
+    */
+  };
+  trace.connect();
   return trace;
 }


### PR DESCRIPTION
This allows closing the connection and re-establishing it. Closing should only be done if all connections are closed as there is no resumption.

Also the peerconnection counter is not affected by this, i.e. will not be reset.

Fixes https://github.com/opentok/rtcstats-server/issues/256

@dagingaa @ggarber PTAL