### PR TITLE
remove the redundant id property on the first getStats result

### DIFF
--- a/rtcstats.js
+++ b/rtcstats.js
@@ -18,10 +18,11 @@ function map2obj(m) {
 function deltaCompression(oldStats, newStats) {
   newStats = JSON.parse(JSON.stringify(newStats));
   Object.keys(newStats).forEach(function(id) {
+    var report = newStats[id];
+    delete report.id;
     if (!oldStats[id]) {
       return;
     }
-    var report = newStats[id];
     Object.keys(report).forEach(function(name) {
       if (report[name] === oldStats[id][name]) {
         delete newStats[id][name];


### PR DESCRIPTION
this is always the same as the id on the outer object. Subsequent delta compression optimizes it away but on the first call it is still quite large. Saves ~2kb on the wire.

breaking change, requires new server version (see multistream branch)