### PR TITLE
compress timestamps

### DIFF
--- a/rtcstats.js
+++ b/rtcstats.js
@@ -33,6 +33,21 @@ function deltaCompression(oldStats, newStats) {
       }
     });
   });
+
+  var timestamp = -Infinity;
+  Object.keys(newStats).forEach(function(id) {
+    var report = newStats[id];
+    if (report.timestamp > timestamp) {
+      timestamp = report.timestamp;
+    }
+  });
+  Object.keys(newStats).forEach(function(id) {
+    var report = newStats[id];
+    if (report.timestamp === timestamp) {
+      report.timestamp = 0;
+    }
+  });
+  newStats.timestamp = timestamp;
   return newStats;
 }
 


### PR DESCRIPTION
fixes #89 - compresses the timestamps by replacing duplicates with 0. The server needs to backfill this from the overall timestamp (or possibly the event timestamp?)

(requires major version bump)