### PR TITLE
Disable auto connect / Prevent exceptions bubbling.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,10 @@
  {
+  "env": {
+    "es6": true
+  },
+  "parserOptions": {
+    "ecmaVersion": 2018
+  },
   "rules": {
     "no-underscore-dangle": 0,
     "no-eq-null": 0,
@@ -16,14 +22,11 @@
     "no-plusplus": 0,
     "prefer-template": 0,
     "object-shorthand": 0,
-
     "no-undef": 0,
     "new-cap": 0,
     "no-param-reassign": 0,
     "consistent-this": 0,
-
     "no-warning-comments": 0,
-     
     "comma-dangle": ["error", {
         "arrays": "only-multiline",
         "objects": "only-multiline",

--- a/package.json
+++ b/package.json
@@ -9,12 +9,12 @@
     "eslint": "^6.8.0",
     "eslint-plugin-require-path-exists": "^1.1.9",
     "tape": "^4.10.1",
-    "travis-multirunner": "^4.5.0",
-    "uglify-js": "^2.6.1"
+    "terser": "^4.8.0",
+    "travis-multirunner": "^4.5.0"
   },
   "scripts": {
     "test": "./node_modules/.bin/eslint rtcstats.js trace-ws.js nonmodule.js && npm run dist",
-    "dist": "mkdir -p out && browserify -o out/rtcstats.js nonmodule.js && uglifyjs -o min.js out/rtcstats.js"
+    "dist": "mkdir -p out && browserify -o out/rtcstats.js nonmodule.js && terser out/rtcstats.js -o rtcstats.min.js"
   },
   "repository": {
     "type": "git",

--- a/rtcstats.js
+++ b/rtcstats.js
@@ -166,13 +166,11 @@ module.exports = function(trace, getStatsInterval, prefixesToWrap) {
         if (constraints) {
           trace('constraints', id, constraints);
         }
-        throw "PeerConnection Caboooommmm!";
 
         pc.addEventListener('icecandidate', function(e) {
           trace('onicecandidate', id, e.candidate);
         });
         pc.addEventListener('addstream', function(e) {
-          throw "Caboooommmm!";
           trace('onaddstream', id, e.stream.id + ' ' + e.stream.getTracks().map(function(t) { return t.kind + ':' + t.id; }));
         });
         pc.addEventListener('track', function(e) {
@@ -240,7 +238,7 @@ module.exports = function(trace, getStatsInterval, prefixesToWrap) {
         return pc;
       } catch (error) {
         // If something went wrong, return a normal PeerConnection
-        console.warn('RTCStats PeerConnection bind failed: ', error);
+        console.error('RTCStats PeerConnection bind failed: ', error);
 
         return new origPeerConnection(origConfig, origConstraints);
       }
@@ -253,7 +251,7 @@ module.exports = function(trace, getStatsInterval, prefixesToWrap) {
           try {
             trace(method, this.__rtcStatsId, arguments);
           } catch (error) {
-            console.warn(`RTCStats ${method} bind failed: `, error);
+            console.error(`RTCStats ${method} bind failed: `, error);
           }
 
           return nativeMethod.apply(this, arguments);
@@ -274,7 +272,7 @@ module.exports = function(trace, getStatsInterval, prefixesToWrap) {
             trace(method, this.__rtcStatsId, stream.id + ' ' + streamInfo);        
           }
           catch (error) {
-            console.warn(`RTCStats ${method} bind failed: `, error);
+            console.error(`RTCStats ${method} bind failed: `, error);
           }
 
           return nativeMethod.apply(this, arguments);
@@ -292,7 +290,7 @@ module.exports = function(trace, getStatsInterval, prefixesToWrap) {
             trace(method, this.__rtcStatsId, track.kind + ':' + track.id + ' ' + (streams.map(function(s) { return 'stream:' + s.id; }).join(';') || '-'));      
           }
           catch (error) {
-            console.warn(`RTCStats ${method} bind failed: `, error);
+            console.error(`RTCStats ${method} bind failed: `, error);
           }
 
           return nativeMethod.apply(this, arguments);
@@ -309,7 +307,7 @@ module.exports = function(trace, getStatsInterval, prefixesToWrap) {
             trace(method, this.__rtcStatsId, track ? track.kind + ':' + track.id : 'null');
           }
           catch (error) {
-            console.warn(`RTCStats ${method} bind failed: `, error);
+            console.error(`RTCStats ${method} bind failed: `, error);
           }
 
           return nativeMethod.apply(this, arguments);
@@ -337,7 +335,7 @@ module.exports = function(trace, getStatsInterval, prefixesToWrap) {
           try {
             trace(method, this.__rtcStatsId, opts);
           } catch (error) {
-            console.warn(`RTCStats ${method} bind failed: `, error);
+            console.error(`RTCStats ${method} bind failed: `, error);
           }
 
           return nativeMethod.apply(this, opts ? [opts] : undefined)
@@ -345,7 +343,7 @@ module.exports = function(trace, getStatsInterval, prefixesToWrap) {
             try {
               trace(method + 'OnSuccess', rtcStatsId, description);
             } catch (error) {
-              console.warn(`RTCStats ${method} promise success bind failed: `, error);
+              console.error(`RTCStats ${method} promise success bind failed: `, error);
             }
 
 
@@ -362,7 +360,7 @@ module.exports = function(trace, getStatsInterval, prefixesToWrap) {
             try {
               trace(method + 'OnFailure', rtcStatsId, err.toString());
             } catch (error) {
-              console.warn(`RTCStats ${method} promise failure bind failed: `, error);
+              console.error(`RTCStats ${method} promise failure bind failed: `, error);
             }
 
             // We can't safely bypass this part of logic because it's necessary for Proxying this request.
@@ -388,7 +386,7 @@ module.exports = function(trace, getStatsInterval, prefixesToWrap) {
           try {
             trace(method, this.__rtcStatsId, args[0]);
           } catch (error) {
-            console.warn(`RTCStats ${method} bind failed: `, error);
+            console.error(`RTCStats ${method} bind failed: `, error);
           }
 
           return nativeMethod.apply(this, [args[0]])
@@ -396,7 +394,7 @@ module.exports = function(trace, getStatsInterval, prefixesToWrap) {
             try {
               trace(method + 'OnSuccess', rtcStatsId, undefined);
             } catch (error) {
-              console.warn(`RTCStats ${method} promise success bind failed: `, error);
+              console.error(`RTCStats ${method} promise success bind failed: `, error);
             }
             
             // We can't safely bypass this part of logic because it's necessary for Proxying this request.
@@ -410,7 +408,7 @@ module.exports = function(trace, getStatsInterval, prefixesToWrap) {
             try {
               trace(method + 'OnFailure', rtcStatsId, err.toString());
             } catch (error) {
-              console.warn(`RTCStats ${method} promise failure bind failed: `, error);
+              console.error(`RTCStats ${method} promise failure bind failed: `, error);
             }
 
             // We can't safely bypass this part of logic because it's necessary for Proxying this request.
@@ -450,7 +448,7 @@ module.exports = function(trace, getStatsInterval, prefixesToWrap) {
       try {
         trace('getUserMedia', null, arguments[0]);
       } catch (error) {
-        console.warn(`RTCStats getUserMedia bind failed: `, error);
+        console.error(`RTCStats getUserMedia bind failed: `, error);
       }
 
       var cb = arguments[1];
@@ -460,7 +458,7 @@ module.exports = function(trace, getStatsInterval, prefixesToWrap) {
           try {
             trace('getUserMediaOnSuccess', null, dumpStream(stream));
           } catch (error) {
-            console.warn(`RTCStats getUserMediaOnSuccess bind failed: `, error);
+            console.error(`RTCStats getUserMediaOnSuccess bind failed: `, error);
           }
           // we log the stream id, track ids and tracks readystate since that is ended GUM fails
           // to acquire the cam (in chrome)
@@ -472,7 +470,7 @@ module.exports = function(trace, getStatsInterval, prefixesToWrap) {
           try {
             trace('getUserMediaOnFailure', null, err.name);
           } catch (error) {
-            console.warn(`RTCStats getUserMediaOnFailure bind failed: `, error);
+            console.error(`RTCStats getUserMediaOnFailure bind failed: `, error);
           }
 
           if (eb) {
@@ -490,7 +488,7 @@ module.exports = function(trace, getStatsInterval, prefixesToWrap) {
       try {
         trace('navigator.mediaDevices.getUserMedia', null, arguments[0]);
       } catch (error) {
-        console.warn(`RTCStats navigator.mediaDevices.getUserMedia bind failed: `, error);
+        console.error(`RTCStats navigator.mediaDevices.getUserMedia bind failed: `, error);
       }
 
       return origGetUserMedia.apply(navigator.mediaDevices, arguments)
@@ -498,7 +496,7 @@ module.exports = function(trace, getStatsInterval, prefixesToWrap) {
         try {
           trace('navigator.mediaDevices.getUserMediaOnSuccess', null, dumpStream(stream));
         } catch (error) {
-          console.warn(`RTCStats navigator.mediaDevices.getUserMediaOnSuccess bind failed: `, error);
+          console.error(`RTCStats navigator.mediaDevices.getUserMediaOnSuccess bind failed: `, error);
         }
 
         return stream;
@@ -506,7 +504,7 @@ module.exports = function(trace, getStatsInterval, prefixesToWrap) {
         try {
           trace('navigator.mediaDevices.getUserMediaOnFailure', null, err.name);
         } catch (error) {
-          console.warn(`RTCStats navigator.mediaDevices.getUserMediaOnFailure bind failed: `, error);
+          console.error(`RTCStats navigator.mediaDevices.getUserMediaOnFailure bind failed: `, error);
         }
 
         return Promise.reject(err);
@@ -522,7 +520,7 @@ module.exports = function(trace, getStatsInterval, prefixesToWrap) {
       try {
         trace('navigator.mediaDevices.getDisplayMedia', null, arguments[0]);
       } catch (error) {
-        console.warn(`RTCStats navigator.mediaDevices.getDisplayMedia bind failed: `, error);
+        console.error(`RTCStats navigator.mediaDevices.getDisplayMedia bind failed: `, error);
       }
 
       return origGetDisplayMedia.apply(navigator.mediaDevices, arguments)
@@ -530,7 +528,7 @@ module.exports = function(trace, getStatsInterval, prefixesToWrap) {
         try {
           trace('navigator.mediaDevices.getDisplayMediaOnSuccess', null, dumpStream(stream));
         } catch (error) {
-          console.warn(`RTCStats navigator.mediaDevices.getDisplayMediaOnSuccess bind failed: `, error);
+          console.error(`RTCStats navigator.mediaDevices.getDisplayMediaOnSuccess bind failed: `, error);
         }
 
         return stream;
@@ -538,7 +536,7 @@ module.exports = function(trace, getStatsInterval, prefixesToWrap) {
         try {
           trace('navigator.mediaDevices.getDisplayMediaOnFailure', null, err.name);
         } catch (error) {
-          console.warn(`RTCStats navigator.mediaDevices.getDisplayMediaOnFailure bind failed: `, error);
+          console.error(`RTCStats navigator.mediaDevices.getDisplayMediaOnFailure bind failed: `, error);
         }
 
         return Promise.reject(err);

--- a/rtcstats.js
+++ b/rtcstats.js
@@ -125,6 +125,14 @@ module.exports = function(trace, getStatsInterval, prefixesToWrap) {
     var origPeerConnection = window[prefix + 'RTCPeerConnection'];
     var peerconnection = function(config, constraints) {
       var pc = new origPeerConnection(config, constraints);
+      if (config && config.iceServers[0] && config.iceServers[0].urls ) {
+        for (const iceUrl of config.iceServers[0].urls) {
+          if (iceUrl.indexOf('taas.callstats.io') >= 0) {
+            return pc;
+          }
+        }
+      }
+
       var id = 'PC_' + peerconnectioncounter++;
       pc.__rtcStatsId = id;
 

--- a/rtcstats.js
+++ b/rtcstats.js
@@ -124,119 +124,138 @@ module.exports = function(trace, getStatsInterval, prefixesToWrap) {
     }
     var origPeerConnection = window[prefix + 'RTCPeerConnection'];
     var peerconnection = function(config, constraints) {
-      var pc = new origPeerConnection(config, constraints);
-      if (config && config.iceServers[0] && config.iceServers[0].urls ) {
-        for (const iceUrl of config.iceServers[0].urls) {
-          if (iceUrl.indexOf('taas.callstats.io') >= 0) {
-            return pc;
+      // We want to make sure that any potential errors that occur at this point, caused by rtcstats logic,
+      // does not affect the normal flow of any application that might integrate it.
+      const origConfig = {...config};
+      const origConstraints = {...constraints};
+      try {
+        var pc = new origPeerConnection(config, constraints);
+        //
+        if (config && config.iceServers[0] && config.iceServers[0].urls ) {
+          for (const iceUrl of config.iceServers[0].urls) {
+            if (iceUrl.indexOf('taas.callstats.io') >= 0) {
+              return pc;
+            }
           }
         }
-      }
 
-      var id = 'PC_' + peerconnectioncounter++;
-      pc.__rtcStatsId = id;
+        var id = 'PC_' + peerconnectioncounter++;
+        pc.__rtcStatsId = id;
 
-      if (!config) {
-        config = { nullConfig: true };
-      }
-
-      config = JSON.parse(JSON.stringify(config)); // deepcopy
-      // don't log credentials
-      ((config && config.iceServers) || []).forEach(function(server) {
-        delete server.credential;
-      });
-
-      if (isFirefox) {
-        config.browserType = 'moz';
-      } else if (isEdge) {
-        config.browserType = 'edge';
-      } else {
-        config.browserType = 'webkit';
-      }
-
-      trace('create', id, config);
-      // TODO: do we want to log constraints here? They are chrome-proprietary.
-      // http://stackoverflow.com/questions/31003928/what-do-each-of-these-experimental-goog-rtcpeerconnectionconstraints-do
-      if (constraints) {
-        trace('constraints', id, constraints);
-      }
-
-      pc.addEventListener('icecandidate', function(e) {
-        trace('onicecandidate', id, e.candidate);
-      });
-      pc.addEventListener('addstream', function(e) {
-        trace('onaddstream', id, e.stream.id + ' ' + e.stream.getTracks().map(function(t) { return t.kind + ':' + t.id; }));
-      });
-      pc.addEventListener('track', function(e) {
-        trace('ontrack', id, e.track.kind + ':' + e.track.id + ' ' + e.streams.map(function(stream) { return 'stream:' + stream.id; }));
-      });
-      pc.addEventListener('removestream', function(e) {
-        trace('onremovestream', id, e.stream.id + ' ' + e.stream.getTracks().map(function(t) { return t.kind + ':' + t.id; }));
-      });
-      pc.addEventListener('signalingstatechange', function() {
-        trace('onsignalingstatechange', id, pc.signalingState);
-      });
-      pc.addEventListener('iceconnectionstatechange', function() {
-        trace('oniceconnectionstatechange', id, pc.iceConnectionState);
-      });
-      pc.addEventListener('icegatheringstatechange', function() {
-        trace('onicegatheringstatechange', id, pc.iceGatheringState);
-      });
-      pc.addEventListener('connectionstatechange', function() {
-        trace('onconnectionstatechange', id, pc.connectionState);
-      });
-      pc.addEventListener('negotiationneeded', function() {
-        trace('onnegotiationneeded', id, undefined);
-      });
-      pc.addEventListener('datachannel', function(event) {
-        trace('ondatachannel', id, [event.channel.id, event.channel.label]);
-      });
-
-      var prev = {};
-      var getStats = function() {
-        if (isFirefox || isSafari) {
-          pc.getStats(null).then(function(res) {
-            var now = map2obj(res);
-            var base = JSON.parse(JSON.stringify(now)); // our new prev
-            trace('getstats', id, deltaCompression(prev, now));
-            prev = base;
-          });
-        } else {
-          pc.getStats(function(res) {
-            var now = mangleChromeStats(pc, res);
-            var base = JSON.parse(JSON.stringify(now)); // our new prev
-            trace('getstats', id, deltaCompression(prev, now));
-            prev = base;
-          });
+        if (!config) {
+          config = { nullConfig: true };
         }
-      };
-      // TODO: do we want one big interval and all peerconnections
-      //    queried in that or one setInterval per PC?
-      //    we have to collect results anyway so...
-      if (!isEdge && getStatsInterval) {
-        var interval = window.setInterval(function() {
-          if (pc.signalingState === 'closed') {
-            window.clearInterval(interval);
-            return;
-          }
-          getStats();
-        }, getStatsInterval);
-      }
-      if (!isEdge) {
-        pc.addEventListener('iceconnectionstatechange', function() {
-          if (pc.iceConnectionState === 'connected') {
-            getStats();
-          }
+
+        config = JSON.parse(JSON.stringify(config)); // deepcopy
+        // don't log credentials
+        ((config && config.iceServers) || []).forEach(function(server) {
+          delete server.credential;
         });
+
+        if (isFirefox) {
+          config.browserType = 'moz';
+        } else if (isEdge) {
+          config.browserType = 'edge';
+        } else {
+          config.browserType = 'webkit';
+        }
+
+        trace('create', id, config);
+        // TODO: do we want to log constraints here? They are chrome-proprietary.
+        // http://stackoverflow.com/questions/31003928/what-do-each-of-these-experimental-goog-rtcpeerconnectionconstraints-do
+        if (constraints) {
+          trace('constraints', id, constraints);
+        }
+        throw "PeerConnection Caboooommmm!";
+
+        pc.addEventListener('icecandidate', function(e) {
+          trace('onicecandidate', id, e.candidate);
+        });
+        pc.addEventListener('addstream', function(e) {
+          throw "Caboooommmm!";
+          trace('onaddstream', id, e.stream.id + ' ' + e.stream.getTracks().map(function(t) { return t.kind + ':' + t.id; }));
+        });
+        pc.addEventListener('track', function(e) {
+          trace('ontrack', id, e.track.kind + ':' + e.track.id + ' ' + e.streams.map(function(stream) { return 'stream:' + stream.id; }));
+        });
+        pc.addEventListener('removestream', function(e) {
+          trace('onremovestream', id, e.stream.id + ' ' + e.stream.getTracks().map(function(t) { return t.kind + ':' + t.id; }));
+        });
+        pc.addEventListener('signalingstatechange', function() {
+          trace('onsignalingstatechange', id, pc.signalingState);
+        });
+        pc.addEventListener('iceconnectionstatechange', function() {
+          trace('oniceconnectionstatechange', id, pc.iceConnectionState);
+        });
+        pc.addEventListener('icegatheringstatechange', function() {
+          trace('onicegatheringstatechange', id, pc.iceGatheringState);
+        });
+        pc.addEventListener('connectionstatechange', function() {
+          trace('onconnectionstatechange', id, pc.connectionState);
+        });
+        pc.addEventListener('negotiationneeded', function() {
+          trace('onnegotiationneeded', id, undefined);
+        });
+        pc.addEventListener('datachannel', function(event) {
+          trace('ondatachannel', id, [event.channel.id, event.channel.label]);
+        });
+
+        var prev = {};
+        var getStats = function() {
+          if (isFirefox || isSafari) {
+            pc.getStats(null).then(function(res) {
+              var now = map2obj(res);
+              var base = JSON.parse(JSON.stringify(now)); // our new prev
+              trace('getstats', id, deltaCompression(prev, now));
+              prev = base;
+            });
+          } else {
+            pc.getStats(function(res) {
+              var now = mangleChromeStats(pc, res);
+              var base = JSON.parse(JSON.stringify(now)); // our new prev
+              trace('getstats', id, deltaCompression(prev, now));
+              prev = base;
+            });
+          }
+        };
+        // TODO: do we want one big interval and all peerconnections
+        //    queried in that or one setInterval per PC?
+        //    we have to collect results anyway so...
+        if (!isEdge && getStatsInterval) {
+          var interval = window.setInterval(function() {
+            if (pc.signalingState === 'closed') {
+              window.clearInterval(interval);
+              return;
+            }
+            getStats();
+          }, getStatsInterval);
+        }
+        if (!isEdge) {
+          pc.addEventListener('iceconnectionstatechange', function() {
+            if (pc.iceConnectionState === 'connected') {
+              getStats();
+            }
+          });
+        }
+        return pc;
+      } catch (error) {
+        // If something went wrong, return a normal PeerConnection
+        console.warn('RTCStats PeerConnection bind failed: ', error);
+
+        return new origPeerConnection(origConfig, origConstraints);
       }
-      return pc;
     };
 
     ['createDataChannel', 'close'].forEach(function(method) {
       var nativeMethod = origPeerConnection.prototype[method];
       if (nativeMethod) {
         origPeerConnection.prototype[method] = function() {
-          trace(method, this.__rtcStatsId, arguments);
+          try {
+            trace(method, this.__rtcStatsId, arguments);
+          } catch (error) {
+            console.warn(`RTCStats ${method} bind failed: `, error);
+          }
+
           return nativeMethod.apply(this, arguments);
         };
       }
@@ -246,12 +265,18 @@ module.exports = function(trace, getStatsInterval, prefixesToWrap) {
       var nativeMethod = origPeerConnection.prototype[method];
       if (nativeMethod) {
         origPeerConnection.prototype[method] = function() {
-          var stream = arguments[0];
-          var streamInfo = stream.getTracks().map(function(t) {
-            return t.kind + ':' + t.id;
-          }).join(',');
+          try {
+            var stream = arguments[0];
+            var streamInfo = stream.getTracks().map(function(t) {
+              return t.kind + ':' + t.id;
+            }).join(',');
+            
+            trace(method, this.__rtcStatsId, stream.id + ' ' + streamInfo);        
+          }
+          catch (error) {
+            console.warn(`RTCStats ${method} bind failed: `, error);
+          }
 
-          trace(method, this.__rtcStatsId, stream.id + ' ' + streamInfo);
           return nativeMethod.apply(this, arguments);
         };
       }
@@ -261,9 +286,15 @@ module.exports = function(trace, getStatsInterval, prefixesToWrap) {
       var nativeMethod = origPeerConnection.prototype[method];
       if (nativeMethod) {
         origPeerConnection.prototype[method] = function() {
-          var track = arguments[0];
-          var streams = [].slice.call(arguments, 1);
-          trace(method, this.__rtcStatsId, track.kind + ':' + track.id + ' ' + (streams.map(function(s) { return 'stream:' + s.id; }).join(';') || '-'));
+          try {
+            var track = arguments[0];
+            var streams = [].slice.call(arguments, 1);
+            trace(method, this.__rtcStatsId, track.kind + ':' + track.id + ' ' + (streams.map(function(s) { return 'stream:' + s.id; }).join(';') || '-'));      
+          }
+          catch (error) {
+            console.warn(`RTCStats ${method} bind failed: `, error);
+          }
+
           return nativeMethod.apply(this, arguments);
         };
       }
@@ -273,8 +304,14 @@ module.exports = function(trace, getStatsInterval, prefixesToWrap) {
       var nativeMethod = origPeerConnection.prototype[method];
       if (nativeMethod) {
         origPeerConnection.prototype[method] = function() {
-          var track = arguments[0].track;
-          trace(method, this.__rtcStatsId, track ? track.kind + ':' + track.id : 'null');
+          try {
+            var track = arguments[0].track;
+            trace(method, this.__rtcStatsId, track ? track.kind + ':' + track.id : 'null');
+          }
+          catch (error) {
+            console.warn(`RTCStats ${method} bind failed: `, error);
+          }
+
           return nativeMethod.apply(this, arguments);
         };
       }
@@ -284,6 +321,8 @@ module.exports = function(trace, getStatsInterval, prefixesToWrap) {
       var nativeMethod = origPeerConnection.prototype[method];
       if (nativeMethod) {
         origPeerConnection.prototype[method] = function() {
+          // The logic here extracts the arguments and establishes if the API 
+          // is callback or Promise based. 
           var rtcStatsId = this.__rtcStatsId;
           var args = arguments;
           var opts;
@@ -292,19 +331,45 @@ module.exports = function(trace, getStatsInterval, prefixesToWrap) {
           } else if (arguments.length === 3 && typeof arguments[2] === 'object') {
             opts = arguments[2];
           }
-          trace(method, this.__rtcStatsId, opts);
+
+          // We can only put a "barrier" at this point because the above logic is 
+          // necessary in all cases, if something fails there we can't just bypass it. 
+          try {
+            trace(method, this.__rtcStatsId, opts);
+          } catch (error) {
+            console.warn(`RTCStats ${method} bind failed: `, error);
+          }
+
           return nativeMethod.apply(this, opts ? [opts] : undefined)
           .then(function(description) {
-            trace(method + 'OnSuccess', rtcStatsId, description);
+            try {
+              trace(method + 'OnSuccess', rtcStatsId, description);
+            } catch (error) {
+              console.warn(`RTCStats ${method} promise success bind failed: `, error);
+            }
+
+
+            // We can't safely bypass this part of logic because it's necessary for Proxying this request.
+            // It determines weather the call is callback or promise based.
             if (args.length > 0 && typeof args[0] === 'function') {
               args[0].apply(null, [description]);
+
               return undefined;
             }
+
             return description;
           }, function(err) {
-            trace(method + 'OnFailure', rtcStatsId, err.toString());
+            try {
+              trace(method + 'OnFailure', rtcStatsId, err.toString());
+            } catch (error) {
+              console.warn(`RTCStats ${method} promise failure bind failed: `, error);
+            }
+
+            // We can't safely bypass this part of logic because it's necessary for Proxying this request.
+            // It determines weather the call is callback or promise based.
             if (args.length > 1 && typeof args[1] === 'function') {
               args[1].apply(null, [err]);
+
               return;
             }
             throw err;
@@ -319,17 +384,37 @@ module.exports = function(trace, getStatsInterval, prefixesToWrap) {
         origPeerConnection.prototype[method] = function() {
           var rtcStatsId = this.__rtcStatsId;
           var args = arguments;
-          trace(method, this.__rtcStatsId, args[0]);
+         
+          try {
+            trace(method, this.__rtcStatsId, args[0]);
+          } catch (error) {
+            console.warn(`RTCStats ${method} bind failed: `, error);
+          }
+
           return nativeMethod.apply(this, [args[0]])
           .then(function() {
-            trace(method + 'OnSuccess', rtcStatsId, undefined);
+            try {
+              trace(method + 'OnSuccess', rtcStatsId, undefined);
+            } catch (error) {
+              console.warn(`RTCStats ${method} promise success bind failed: `, error);
+            }
+            
+            // We can't safely bypass this part of logic because it's necessary for Proxying this request.
+            // It determines weather the call is callback or promise based.
             if (args.length >= 2 && typeof args[1] === 'function') {
               args[1].apply(null, []);
               return undefined;
             }
             return undefined;
           }, function(err) {
-            trace(method + 'OnFailure', rtcStatsId, err.toString());
+            try {
+              trace(method + 'OnFailure', rtcStatsId, err.toString());
+            } catch (error) {
+              console.warn(`RTCStats ${method} promise failure bind failed: `, error);
+            }
+
+            // We can't safely bypass this part of logic because it's necessary for Proxying this request.
+            // It determines weather the call is callback or promise based
             if (args.length >= 3 && typeof args[2] === 'function') {
               args[2].apply(null, [err]);
               return undefined;
@@ -362,20 +447,34 @@ module.exports = function(trace, getStatsInterval, prefixesToWrap) {
     }
     var origGetUserMedia = navigator[name].bind(navigator);
     var gum = function() {
-      trace('getUserMedia', null, arguments[0]);
+      try {
+        trace('getUserMedia', null, arguments[0]);
+      } catch (error) {
+        console.warn(`RTCStats getUserMedia bind failed: `, error);
+      }
+
       var cb = arguments[1];
       var eb = arguments[2];
       origGetUserMedia(arguments[0],
         function(stream) {
+          try {
+            trace('getUserMediaOnSuccess', null, dumpStream(stream));
+          } catch (error) {
+            console.warn(`RTCStats getUserMediaOnSuccess bind failed: `, error);
+          }
           // we log the stream id, track ids and tracks readystate since that is ended GUM fails
           // to acquire the cam (in chrome)
-          trace('getUserMediaOnSuccess', null, dumpStream(stream));
           if (cb) {
             cb(stream);
           }
         },
         function(err) {
-          trace('getUserMediaOnFailure', null, err.name);
+          try {
+            trace('getUserMediaOnFailure', null, err.name);
+          } catch (error) {
+            console.warn(`RTCStats getUserMediaOnFailure bind failed: `, error);
+          }
+
           if (eb) {
             eb(err);
           }
@@ -388,13 +487,28 @@ module.exports = function(trace, getStatsInterval, prefixesToWrap) {
   if (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {
     var origGetUserMedia = navigator.mediaDevices.getUserMedia.bind(navigator.mediaDevices);
     var gum = function() {
-      trace('navigator.mediaDevices.getUserMedia', null, arguments[0]);
+      try {
+        trace('navigator.mediaDevices.getUserMedia', null, arguments[0]);
+      } catch (error) {
+        console.warn(`RTCStats navigator.mediaDevices.getUserMedia bind failed: `, error);
+      }
+
       return origGetUserMedia.apply(navigator.mediaDevices, arguments)
       .then(function(stream) {
-        trace('navigator.mediaDevices.getUserMediaOnSuccess', null, dumpStream(stream));
+        try {
+          trace('navigator.mediaDevices.getUserMediaOnSuccess', null, dumpStream(stream));
+        } catch (error) {
+          console.warn(`RTCStats navigator.mediaDevices.getUserMediaOnSuccess bind failed: `, error);
+        }
+
         return stream;
       }, function(err) {
-        trace('navigator.mediaDevices.getUserMediaOnFailure', null, err.name);
+        try {
+          trace('navigator.mediaDevices.getUserMediaOnFailure', null, err.name);
+        } catch (error) {
+          console.warn(`RTCStats navigator.mediaDevices.getUserMediaOnFailure bind failed: `, error);
+        }
+
         return Promise.reject(err);
       });
     };
@@ -405,13 +519,28 @@ module.exports = function(trace, getStatsInterval, prefixesToWrap) {
   if (navigator.mediaDevices && navigator.mediaDevices.getDisplayMedia) {
     var origGetDisplayMedia = navigator.mediaDevices.getDisplayMedia.bind(navigator.mediaDevices);
     var gdm = function() {
-      trace('navigator.mediaDevices.getDisplayMedia', null, arguments[0]);
+      try {
+        trace('navigator.mediaDevices.getDisplayMedia', null, arguments[0]);
+      } catch (error) {
+        console.warn(`RTCStats navigator.mediaDevices.getDisplayMedia bind failed: `, error);
+      }
+
       return origGetDisplayMedia.apply(navigator.mediaDevices, arguments)
       .then(function(stream) {
-        trace('navigator.mediaDevices.getDisplayMediaOnSuccess', null, dumpStream(stream));
+        try {
+          trace('navigator.mediaDevices.getDisplayMediaOnSuccess', null, dumpStream(stream));
+        } catch (error) {
+          console.warn(`RTCStats navigator.mediaDevices.getDisplayMediaOnSuccess bind failed: `, error);
+        }
+
         return stream;
       }, function(err) {
-        trace('navigator.mediaDevices.getDisplayMediaOnFailure', null, err.name);
+        try {
+          trace('navigator.mediaDevices.getDisplayMediaOnFailure', null, err.name);
+        } catch (error) {
+          console.warn(`RTCStats navigator.mediaDevices.getDisplayMediaOnFailure bind failed: `, error);
+        }
+
         return Promise.reject(err);
       });
     };

--- a/trace-ws.js
+++ b/trace-ws.js
@@ -1,7 +1,7 @@
 var PROTOCOL_VERSION = '2.0';
 module.exports = function(wsURL) {
-  var buffer;
-  var connection;
+  var buffer = [];
+  var connection = undefined;
   var trace = function() {
     //console.log.apply(console, arguments);
     // TODO: drop getStats when not connected?
@@ -10,9 +10,9 @@ module.exports = function(wsURL) {
     if (args[1] instanceof RTCPeerConnection) {
       args[1] = args[1].__rtcStatsId;
     }
-    if (connection.readyState === WebSocket.OPEN) {
+    if (connection && (connection.readyState === WebSocket.OPEN)) {
       connection.send(JSON.stringify(args));
-    } else if (connection.readyState >= WebSocket.CLOSING) {
+    } else if (connection && (connection.readyState >= WebSocket.CLOSING)) {
       // no-op. Possibly log?
     } else if (args[0] !== 'getstats') {
       buffer.push(args);
@@ -50,6 +50,6 @@ module.exports = function(wsURL) {
     };
     */
   };
-  trace.connect();
+  //trace.connect();
   return trace;
 };

--- a/trace-ws.js
+++ b/trace-ws.js
@@ -20,7 +20,7 @@ module.exports = function(wsURL) {
   };
 
   trace.close = function() {
-    connection.close();
+    connection && connection.close();
   };
   trace.connect = function() {
     buffer = [];


### PR DESCRIPTION
Allow clients to decide when they want to connect to the rtcstats server, operations that happen while not connected get buffered. 
Exception handlers have been added for every function in case some goes wrong the client won't be affected by it, an error is logged and the default behaviour is used.
Uglifyjs was replaced with Terser because it lacked support for es6, from what I observed terser also creates smaller files.