### PR TITLE
Minor changes: ES6, example page and optional args

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,10 @@
  {
+  "env": {
+      "es6": true
+  },
+  "parserOptions": {
+      "sourceType": "module"
+  },
   "rules": {
     "no-underscore-dangle": 0,
     "no-eq-null": 0,

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ this will create the output in `./out/`
 #### require
 
 ```javascript
-const trace = require("rtcstats/trace-ws")("wss://rtcstats.appear.in"); // url-to-your-websocket-server
+const trace = require("rtcstats/trace-ws")("wss://rtcstats.myserver.com"); // url-to-your-websocket-server
 require("rtcstats")(
    trace,
    1000, // interval at which getStats will be polled.

--- a/example/index.html
+++ b/example/index.html
@@ -1,0 +1,73 @@
+<html>
+<head>
+<meta charset="utf-8">
+<title>Test page for rtcstats</title>
+<link rel="shortcut icon" href="data:image/x-icon;," type="image/x-icon"> 
+</head>
+<body>
+<h1>Test page for rtcstats</h1>
+<br>
+The browser version is: <span id="browserversion"></span>
+<video id="local" muted autoplay></video>
+<video id="remote" muted autoplay></video>
+<button id="camera">Connect with camera</button>
+<button id="screen">Connect with screen</button>
+<script type="module">
+  import RTCStats from '../rtcstats.js';
+  import RTCTrace from '../trace-ws.js';
+
+  const trace = RTCTrace("ws://localhost:9999");
+  RTCStats(trace, 10000);
+
+  async function connect(stream) {
+    document.getElementById('local').srcObject = stream;
+
+    const pc1 = new RTCPeerConnection({}, { optional: [
+      {rtcStatsClientId: "your client identifier"},
+      {rtcStatsPeerId: "identifier for the current peer"},
+      {rtcStatsConferenceId: "identifier for the conference, e.g. room name"}
+    ]});
+    const pc2 = new RTCPeerConnection({}, { optional: [
+      {rtcStatsClientId: "your client identifier"},
+      {rtcStatsPeerId: "identifier for the current peer"},
+      {rtcStatsConferenceId: "identifier for the conference, e.g. room name"}
+    ]});
+    stream.getTracks().forEach(track => pc1.addTrack(track, stream));
+    
+    pc2.ontrack = (event) => {
+      if (event.track.kind === 'video') {
+        document.getElementById('remote').srcObject = event.streams[0];
+      }
+    };
+    pc1.onicecandidate = (event) => {
+      if (event.candidate) {
+        pc2.addIceCandidate(event.candidate);
+      }
+    };
+    pc2.onicecandidate = (event) => {
+      if (event.candidate) {
+        pc1.addIceCandidate(event.candidate);
+      }
+    };
+    const offer = await pc1.createOffer();
+    await pc1.setLocalDescription(offer);
+    await pc2.setRemoteDescription(offer);
+    const answer = await pc2.createAnswer();
+    await pc2.setLocalDescription(answer);
+    await pc1.setRemoteDescription(answer);
+  }
+
+  async function startWithCamera() {
+    const stream = await navigator.mediaDevices.getUserMedia({ video: true, audio: true });
+    await connect(stream);
+  }
+  document.getElementById('camera').addEventListener('click', startWithCamera);
+
+  async function startWithScreen() {
+    const stream = await navigator.mediaDevices.getDisplayMedia({ video: true, audio: true });
+    await connect(stream);
+  }
+  document.getElementById('screen').addEventListener('click', startWithScreen);
+</script>
+</body>
+</html>

--- a/nonmodule.js
+++ b/nonmodule.js
@@ -1,6 +1,0 @@
-// helper script to create the non-module version with some defaults.
-require('./rtcstats')(
-    require('./trace-ws')('wss://rtcstats.tokbox.com'),
-    1000,
-    ['', 'webkit', 'moz']
-);

--- a/rtcstats.d.ts
+++ b/rtcstats.d.ts
@@ -48,5 +48,5 @@ declare module "rtcstats" {
      * addIceCandidateOnFailure - string
      */
 
-    export default function anonymous(trace: (method: string, id: string, data: RTCStatsDataType) => void, getStatsIntervalmsec: number, prefixesToWrap: string[]): void;
+    export default function anonymous(trace: (method: string, id: string, data: RTCStatsDataType) => void, getStatsIntervalmsec: number, prefixesToWrap?: string[]): void;
 }

--- a/rtcstats.js
+++ b/rtcstats.js
@@ -109,7 +109,7 @@ function removeTimestamps(results) {
 }
 */
 
-module.exports = function(trace, getStatsInterval, prefixesToWrap) {
+export default function(trace, getStatsInterval, prefixesToWrap = ['']) {
   var peerconnectioncounter = 0;
   var isFirefox = !!window.mozRTCPeerConnection;
   var isEdge = !!window.RTCIceGatherer;

--- a/trace-ws.js
+++ b/trace-ws.js
@@ -1,5 +1,5 @@
-var PROTOCOL_VERSION = '2.0';
-module.exports = function(wsURL) {
+const PROTOCOL_VERSION = '2.0';
+export default function(wsURL) {
   var buffer;
   var connection;
   var trace = function() {


### PR DESCRIPTION
- Remove references to tokbox and appear.in
- Add sample page
- Make prefixesToWrap optional
- Use ES6 modules instead of module.exports and set eslint to ES6 to allow const/let variables